### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/src-web/pages/database/ai/services.ts
+++ b/src-web/pages/database/ai/services.ts
@@ -115,6 +115,7 @@ const createLanguageModel = (config: ProviderConfig, modelID: string): LanguageM
         case ProviderType.Ollama:
         case ProviderType.OpenAI:
         case ProviderType.OpenRouter:
+        case ProviderType.Requesty:
         case ProviderType.VercelAIGateway:
         case ProviderType.xAI:
         case ProviderType.OpenAICompatible: {

--- a/src-web/pages/settings/provider/api.ts
+++ b/src-web/pages/settings/provider/api.ts
@@ -13,6 +13,7 @@ export const defaultBaseURL = (type: ProviderType): string => {
         [ProviderType.Ollama]: 'http://localhost:11434/v1',
         [ProviderType.OpenAI]: 'https://api.openai.com/v1',
         [ProviderType.OpenRouter]: 'https://openrouter.ai/api/v1',
+        [ProviderType.Requesty]: 'https://router.requesty.ai/v1',
         [ProviderType.VercelAIGateway]: 'https://ai-gateway.vercel.sh/v1',
         [ProviderType.xAI]: 'https://api.x.ai/v1',
         [ProviderType.OpenAICompatible]: ''
@@ -69,7 +70,8 @@ export const fetchModels = async (config: ProviderConfig): Promise<ProviderModel
             return fetchJSON(`${baseURL}/models`, schema, headers).then((json) => json.data)
         }
         case ProviderType.Mistral:
-        case ProviderType.OpenRouter: {
+        case ProviderType.OpenRouter:
+        case ProviderType.Requesty: {
             const schema = z.object({
                 data: z.array(
                     z.object({

--- a/src-web/pages/settings/provider/provider-icon.tsx
+++ b/src-web/pages/settings/provider/provider-icon.tsx
@@ -110,6 +110,18 @@ export const ProviderIcon = ({ type, selected }: { type: ProviderType; selected?
                 </svg>
             )
         }
+        // Requesty is an OpenAI-compatible provider (like OpenRouter); reuse the
+        // generic server icon since there is no dedicated Requesty asset imported.
+        case ProviderType.Requesty: {
+            return (
+                <IconServer
+                    data-selected={selected || undefined}
+                    size={16}
+                    strokeWidth={1.5}
+                    className='shrink-0 text-primary data-[selected]:text-white'
+                />
+            )
+        }
         case ProviderType.VercelAIGateway: {
             return (
                 <svg

--- a/src-web/tauri/client.ts
+++ b/src-web/tauri/client.ts
@@ -166,6 +166,7 @@ export const enum ProviderType {
     Ollama = 'Ollama',
     OpenAI = 'OpenAI',
     OpenRouter = 'OpenRouter',
+    Requesty = 'Requesty',
     VercelAIGateway = 'Vercel AI Gateway',
     xAI = 'xAI',
     OpenAICompatible = 'OpenAI Compatible'
@@ -181,6 +182,7 @@ export const ALL_PROVIDER_TYPES = [
     ProviderType.Ollama,
     ProviderType.OpenAI,
     ProviderType.OpenRouter,
+    ProviderType.Requesty,
     ProviderType.VercelAIGateway,
     ProviderType.xAI,
     ProviderType.OpenAICompatible
@@ -196,6 +198,7 @@ export type ProviderConfig =
     | OllamaConfig
     | OpenAIConfig
     | OpenRouterConfig
+    | RequestyConfig
     | VercelAIGatewayConfig
     | xAIConfig
     | OpenAICompatibleConfig
@@ -214,6 +217,7 @@ export type MistralConfig = BaseProviderConfig & { type: ProviderType.Mistral }
 export type OllamaConfig = BaseProviderConfig & { type: ProviderType.Ollama }
 export type OpenAIConfig = BaseProviderConfig & { type: ProviderType.OpenAI }
 export type OpenRouterConfig = BaseProviderConfig & { type: ProviderType.OpenRouter }
+export type RequestyConfig = BaseProviderConfig & { type: ProviderType.Requesty }
 export type VercelAIGatewayConfig = BaseProviderConfig & { type: ProviderType.VercelAIGateway }
 export type xAIConfig = BaseProviderConfig & { type: ProviderType.xAI }
 export type OpenAICompatibleConfig = BaseProviderConfig & { type: ProviderType.OpenAICompatible }


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter `ProviderType`.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router with an OpenAI-shaped `/models` endpoint, so it behaves like OpenRouter for model listing and chat.

Changes: add the `Requesty` enum member + config type (`tauri/client.ts`), default base URL and `/models` fetch case (`settings/provider/api.ts`), provider icon (`provider-icon.tsx`), and the OpenAI-compatible client case (`database/ai/services.ts`).

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.